### PR TITLE
json schema fixes and python example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 ## Table of Contents
 
 - [RaaS API - Version 1](#raas-api---version-1)
-	- [Table of Contents](#table-of-contents)
-	- [What is RaaS](#what-is-raas)
+	- [What is RaaS](#what-is-the-raas-api)
 	- [System-wide Notes](#system-wide-notes)
 	- [SSL/TLS](#ssltls)
 - [Resources](#resources)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ The Certificate Authority that issued our server certificates is [DigiCert](http
  curl_exec($curl);
  ```
  
+ ```python
+ # python (using requests)
+import requests
+from requests.auth import HTTPBasicAuth
+# SSL is used by default.
+requests.get('https://integration-api.tangocard.com/fake/example',
+             auth=HTTPBasicAuth(username, password))
+```
+
 One thing to take note of in both examples is that OpenSSL is being instructed to **VERIFY PEER**. This setting is essential as without it you will know that your communication is encrypted, but you won't know who it is you're talking to.
  
 Note: We use a wild-card certificate from DigiCert and hence the certificate chain is the same for both Sandbox and Production environments.

--- a/cc_fund.schema.json
+++ b/cc_fund.schema.json
@@ -14,7 +14,7 @@
             "type":"string",
             "minLength":5,
             "maxLength":96,
-            "pattern":"^[\\\\+\\\\w-]{5,96}$"
+            "pattern":"^[\\+\\w-]{5,96}$"
         },
         "amount":{
             "description":"The amount to add to the account (and thus, charge the credit card), in cents.",
@@ -32,7 +32,7 @@
         "security_code":{
             "description":"The 3 or 4-digit card security code (CVV2, CVC2, or CID).",
             "type":"string",
-            "pattern":"^\\\\d{3,4}$"
+            "pattern":"^\\d{3,4}$"
         }
     },
     "required":["customer","account_identifier","amount","client_ip","cc_token","security_code"]

--- a/cc_fund.schema.json
+++ b/cc_fund.schema.json
@@ -1,10 +1,10 @@
 {
     "$schema":"http://json-schema.org/draft-04/schema#",
-    "title":"Fund a platform user\'s account.",
+    "title":"Fund a platform user's account.",
     "type":"object",
     "properties":{
         "customer":{
-            "description":"The platform\'s customer.",
+            "description":"The platform's customer.",
             "type":"string",
             "minLength":1,
             "maxLength":96

--- a/cc_register.schema.json
+++ b/cc_register.schema.json
@@ -14,7 +14,7 @@
             "type":"string",
             "minLength":5,
             "maxLength":96,
-            "pattern":"^[\\\\+\\\\w-]{5,96}$"
+            "pattern":"^[\\+\\w-]{5,96}$"
         },
         "client_ip":{
             "description":"The IP address of the person making the purchase.",
@@ -38,7 +38,7 @@
                 "security_code":{
                     "description":"The 3 or 4-digit card security code (CVV2, CVC2, or CID).",
                     "type":"string",
-                    "pattern":"^\\\\d{3,4}$"
+                    "pattern":"^\\d{3,4}$"
                 },
                 "billing_address":{	
                     "description":"The billing address associated with the credit card.",
@@ -92,7 +92,7 @@
                             "type":"string",
                             "minLength":5,
                             "maxLength":255,
-                            "pattern":"^\\\\S+@\\\\S+$"
+                            "pattern":"^\\S+@\\S+$"
                         }
                     },
                     "required":["f_name","l_name","address","city","state","zip","email"]

--- a/cc_register.schema.json
+++ b/cc_register.schema.json
@@ -1,10 +1,10 @@
 {
     "$schema":"http://json-schema.org/draft-04/schema#",
-    "title":"Register a card to a platform user\'s account.",
+    "title":"Register a card to a platform user's account.",
     "type":"object",
     "properties":{
         "customer":{
-            "description":"The platform\'s customer.",
+            "description":"The platform's customer.",
             "type":"string",
             "minLength":1,
             "maxLength":96
@@ -45,13 +45,13 @@
                     "type":"object",
                     "properties":{
                         "f_name":{
-                            "description":"The first name associated with the customer\'s billing address.",
+                            "description":"The first name associated with the customer's billing address.",
                             "type":"string",
                             "minLength":1,
                             "maxLength":50
                         },
                         "l_name":{
-                            "description":"The last name associated with the customer\'s billing address.",
+                            "description":"The last name associated with the customer's billing address.",
                             "type":"string",
                             "minLength":1,
                             "maxLength":50
@@ -63,32 +63,32 @@
                             "maxLength":60
                         },
                         "city":{
-                            "description":"The city of the customer\'s billing address.",
+                            "description":"The city of the customer's billing address.",
                             "type":"string",
                             "minLength":1,
                             "maxLength":40
                         },
                         "state":{
-                            "description":"The state of the customer\'s billing address. Up to 40 characters (no symbols) or a FIPS state alpha code (e.g. AL, WA, etc).",
+                            "description":"The state of the customer's billing address. Up to 40 characters (no symbols) or a FIPS state alpha code (e.g. AL, WA, etc).",
                             "type":"string",
                             "minLength":1,
                             "maxLength":40
                         },
                         "zip":{
-                            "description":"The postal code of the customer\'s billing address.",
+                            "description":"The postal code of the customer's billing address.",
                             "type":"string",
                             "minLength":1,
                             "maxLength":20
                         },
                         "country":{
-                            "description":"The country of the customer\'s billing address.",
+                            "description":"The country of the customer's billing address.",
                             "type":"string",
                             "minLength":1,
                             "maxLength":60,
                             "optional":true
                         },
                         "email":{
-                            "description":"The customer\'s email address.",
+                            "description":"The customer's email address.",
                             "type":"string",
                             "minLength":5,
                             "maxLength":255,

--- a/cc_unregister.schema.json
+++ b/cc_unregister.schema.json
@@ -4,7 +4,7 @@
     "type":"object",
     "properties":{
         "customer":{
-            "description":"The platform\'s customer.",
+            "description":"The platform's customer.",
             "type":"string",
             "minLength":1,
             "maxLength":96


### PR DESCRIPTION
I ran into a few issues with the json schemas breaking the [json.org spec](http://json.org/spec), but it was an easy fix.

I also added a python example to the README and fixed a broken link in the table of contents.

By the way, I created a simple python wrapper for the API, but I'm not sure if you guys want to mention it in the README or not. https://github.com/jmckib/tangopy

Cheers!

EDIT: This may address #13.